### PR TITLE
Teaching how to add rubocop to the integrate steps

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -134,6 +134,22 @@ SimpleCov.start 'rails' do
 end
 ```
 
+#### Tired of debate coding standards?
+
+Do your team agree with [this Ruby styleguide](https://github.com/bbatsov/ruby-style-guide)? (or at least most of it) Good! Now you can make sure that everyone is following it by installing [rubocop](https://github.com/bbatsov/rubocop) on your app and then making sure that you [enabled their rake tasks](https://github.com/bbatsov/rubocop#rake-integration) and added it to your integrate tasks list:
+
+```ruby
+INTEGRATION_TASKS = %w(
+  jumpup:start
+  jumpup:bundle_install
+  db:migrate
+  spec
+  rubocop
+  jumpup:git:check_last_commit_change
+  jumpup:finish
+)
+```
+
 #### Skip spec
 
 Sometimes we have to change some configuration and deploy as fast as possible. It is possible setting the environment variable `SKIP_SPEC=1` to skip specs.


### PR DESCRIPTION
I'm a huge fan of rubocop, I think we should encourage people to use it. Besides, it helps teams with people that are not used to work together to discuss and debate standards of the project and to follow them afterwards.

It's also a way to teach people how to add "external rake tasks into the integration steps", other than those already listed in the readme.